### PR TITLE
fix: could not configure the pattern

### DIFF
--- a/lib/commands/check.js
+++ b/lib/commands/check.js
@@ -35,6 +35,7 @@ Check.prototype.setUpProcessors = function() {
       new Processor(this.translations, {
         translations: this.translations,
         checkWrapper: this.checkWrapper.bind(this),
+        pattern: this.options.pattern,
         only: this.options.only,
         directory: this.options.directory
       })


### PR DESCRIPTION
Transmit the configured pattern (through the options) to the Processor in order to process exactly the files defined by this supplied pattern.